### PR TITLE
Release 0.7.0

### DIFF
--- a/code/manifest.json
+++ b/code/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_extensionName__",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [


### PR DESCRIPTION
Version bump only. Everything shipping here is already on master via #12.

0.6.0 is live in the store, which unblocks submitting this.

## What users get over 0.6.0

- Each nesting error explains itself on hover, naming the violation and, when the list is short enough to be useful, what the parent may contain.
- A panel gives the total and a breakdown by `parent > child`, so a page's problems can be read off rather than hunted for by scrolling.
- Japanese UI, following the browser's display language.
- Both panels can be closed without reopening the popup.

Permissions are unchanged: `activeTab` and `scripting`.

## Test plan

- [x] `npm test` — 32 assertions passing
- [x] `npm run typecheck` — 0 errors
- [x] `npm run package` — `dist/krafty-0.7.0.zip`, 34,559 bytes, `manifest.json` at the archive root, `_locales` included
- [x] Japanese UI confirmed in a browser

## Note for the store listing

The description still describes 0.5.x behaviour. Worth mentioning that the nest checker now reports reasons and counts, and that the UI is available in Japanese.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
