### PR TITLE
Stop counting an icon's title as the document's

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,6 +153,19 @@ Things to watch for while using it:
   argument for adding one.
 - Whether the alert/note split matches what actually needs acting on.
 
+Found so far, 2026-07-20, on brainpad.co.jp: "title appears 4 times" on a
+page with exactly one title. The duplicate check selected `title`, and in
+an HTML document a type selector matches every namespace, so the `<title>`
+elements inside inline SVG — the accessible names of the icons — were
+counted as document titles. Fixed by scoping to `head > title`.
+
+Worth noting how it was found, because it argues for this whole section.
+The check is a one-line `querySelectorAll` that reads correctly, has a test
+behind it, and was wrong on the first real site it met. Nothing short of
+running it on a page somebody actually built would have surfaced it. The
+same is true of the questions above, which is why they are still open
+rather than guessed at.
+
 ### 8. Overlapping alt labels
 
 The labels are absolutely positioned, so on image-dense pages (EC product

--- a/code/js/headCheck.js
+++ b/code/js/headCheck.js
@@ -182,7 +182,14 @@
     ]);
   }
 
-  reportDuplicates("title", "title");
+  /* "head > title", not "title": in an HTML document a type selector matches
+     every namespace, so a bare "title" also collects the <title> elements
+     inside inline SVG. Those are accessible names for icons, not document
+     titles, and any site with an SVG icon set has several - which reported a
+     duplicate title on a page whose title is perfectly fine. The document
+     title is a child of head by definition, so scoping there is both the
+     narrower and the more accurate reading. */
+  reportDuplicates("head > title", "title");
   reportDuplicates('meta[name="description" i]', "description");
   reportDuplicates('link[rel~="canonical" i]', "canonical");
   reportDuplicates('meta[property="og:title" i]', "og:title");

--- a/test/head.test.js
+++ b/test/head.test.js
@@ -129,6 +129,56 @@ test("head checker", async (t) => {
     assert.strictEqual(duplicates.length, 1);
   });
 
+  await t.test("does not count SVG titles as duplicate document titles", async () => {
+    /* Found on a real site: an icon set drawn as inline SVG, each icon
+       carrying its own <title> as an accessible name. A bare "title"
+       selector matches every namespace in an HTML document, so all of them
+       were counted and the page was told its title was duplicated. */
+    const findings = await withPage(
+      {
+        html: `<p>page</p>
+          <svg viewBox="0 0 16 16"><title>Search</title><path d="M0 0"/></svg>
+          <svg viewBox="0 0 16 16"><title>Menu</title><path d="M0 0"/></svg>
+          <svg viewBox="0 0 16 16"><title>Close</title><path d="M0 0"/></svg>`,
+        checkers: [],
+      },
+      async (page) => {
+        await page.evaluate(() => {
+          document.head.insertAdjacentHTML(
+            "beforeend",
+            `<title>A page about something</title>`
+          );
+        });
+
+        const { SCRIPTS } = require("./support.js");
+        await page.evaluate(SCRIPTS.headCheck);
+
+        return page.evaluate(() =>
+          [
+            ...(document
+              .getElementById("js-kraftyHeadInformation")
+              ?.querySelectorAll(".kraftyCheck") ?? []),
+          ].map((item) => item.textContent ?? "")
+        );
+      }
+    );
+
+    assert.deepStrictEqual(
+      findings.filter((text) => /title appears/.test(text)),
+      [],
+      "an icon's <title> is its accessible name, not a second document title"
+    );
+  });
+
+  await t.test("still reports a genuinely duplicated title", async () => {
+    /* The narrower selector must not have turned the check off. */
+    const { findings } = await check(
+      `<title>First</title><title>Second</title>`
+    );
+
+    assert.strictEqual(matching(findings, /title appears 2 times/).length, 1);
+  });
+
   await t.test("reports a missing lang attribute", async () => {
     const { findings } = await check(SOUND_HEAD);
 

--- a/test/nest.test.js
+++ b/test/nest.test.js
@@ -43,6 +43,21 @@ const CASES = [
   ["div > link[rel=preload] is valid", false, `<div><link rel="preload" as="image" href="/x.png" data-t></div>`],
   ["div > meta is invalid", true, `<div><meta name="x" data-t></div>`],
   ["div > style is invalid", true, `<div><style data-t></style></div>`],
+
+  /* Foreign content. The walk covers every element in the body, including
+     the inside of inline SVG and MathML, where several names collide with
+     HTML ones - title, a, script, style. None of those parents belong to
+     the HTML content model table, so nothing inside them is judged; these
+     pin that, because a false positive here would fire on every site with
+     an icon set. The last case confirms the suppression is not blanket:
+     where the SVG root itself sits is still HTML's business. */
+  ["svg > title is valid", false, `<svg><title data-t>x</title></svg>`],
+  ["svg > a is valid", false, `<svg><a data-t></a></svg>`],
+  ["svg > style is valid", false, `<svg><style data-t></style></svg>`],
+  ["svg > script is valid", false, `<svg><script data-t></script></svg>`],
+  ["svg > g > path is valid", false, `<svg><g><path data-t/></g></svg>`],
+  ["math > mi is valid", false, `<math><mi data-t>x</mi></math>`],
+  ["ul > svg is still invalid", true, `<ul><svg data-t></svg></ul>`],
 ];
 
 /* An element that already has a title: the checker writes its explanation


### PR DESCRIPTION
Found by using 0.8.0 on a real site, which is what roadmap item 7 asked for.

`brainpad.co.jp` reported **"title appears 4 times"** on a page with exactly one title. Three of the four were `<title>` elements inside inline SVG — the accessible names of the icons.

## Cause

The duplicate check selected `title`. In an HTML document a type selector matches **every namespace**, so a bare `title` collects SVG titles alongside the real one. Any site with an SVG icon set has several, which made this finding noise on exactly the kind of page the checker is aimed at.

The other four duplicate checks select `meta` and `link` by attribute, which SVG has neither of. This was the only one affected.

## Fix

Scoped to `head > title`. The document title is a child of `head` by definition, so this is the more accurate reading as well as the narrower one.

## Testing

`npm test` — 90 pass, 0 fail.

Two new tests: an icon set must not be counted, and a genuinely duplicated title must still be. The second is there because the obvious way to silence a false positive is to narrow the selector until it catches nothing at all.

Verified the first one reproduces the report — reinstating the bare selector fails with:

```
+   'title appears 4 times'
```

## Roadmap

Recorded under item 7. Worth noting how this was found: the check is a one-line `querySelectorAll` that reads correctly, had a test behind it, and was wrong on the first real site it met. Nothing short of running it on a page somebody actually built would have surfaced it.

Version stays at 0.8.0 (in review). This ships with 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)