### PR TITLE
Stop a canonical spelling this page differently reading as another page

### DIFF
--- a/code/js/headCheck.js
+++ b/code/js/headCheck.js
@@ -75,6 +75,45 @@
     }
   };
 
+  /**
+   * Whether two addresses name the same page.
+   *
+   * The finding this backs is "the page declares itself not the original",
+   * which is serious. It has to mean a different *page*, not a different
+   * spelling of this one: a canonical of /index.html read from / is the
+   * same document on every static host, and picking one spelling over the
+   * other is precisely what the tag is for. Reported as a contradiction, it
+   * was a false positive on a correctly built site.
+   *
+   * A different host or scheme is still reported. Those are also ordinary
+   * canonicalisation, but they are worth a person's glance in a way that a
+   * directory index is not, and the finding is a note rather than an alert.
+   *
+   * @param {string} a
+   * @param {string} b
+   */
+  const samePage = (a, b) => {
+    /** @param {string} href */
+    const key = (href) => {
+      try {
+        const url = new URL(href);
+        url.hash = "";
+        url.pathname = url.pathname.replace(/\/index\.(html?|php)$/i, "/");
+
+        /* Compared as a key, not rewritten for display, so appending the
+           slash to every path is safe: both sides get it. */
+        if (!url.pathname.endsWith("/")) {
+          url.pathname += "/";
+        }
+        return url.href;
+      } catch (error) {
+        return href;
+      }
+    };
+
+    return key(a) === key(b);
+  };
+
   /** @param {string | null} value */
   const length = (value) => (value ? [...value].length : 0);
 
@@ -163,9 +202,8 @@
     report("note", "checkCanonicalMissing");
   } else {
     const target = resolve(canonical);
-    const here = location.href.split("#")[0];
 
-    if (target && target.split("#")[0] !== here) {
+    if (target && !samePage(target, location.href)) {
       report("note", "checkCanonicalElsewhere", [target]);
     }
   }

--- a/test/head.test.js
+++ b/test/head.test.js
@@ -13,11 +13,11 @@ const { withPage } = require("./support.js");
  * passed as a script that writes it in. Returns the text of each finding.
  *
  * @param {string} headMarkup
- * @param {{ noDoctype?: boolean }} [options]
+ * @param {{ noDoctype?: boolean, serve?: string }} [options]
  */
 async function check(headMarkup, options = {}) {
   return withPage(
-    { html: "<p>page</p>", checkers: [] },
+    { html: "<p>page</p>", checkers: [], serve: options.serve },
     async (page) => {
       await page.evaluate(
         ([markup, quirks]) => {
@@ -115,9 +115,51 @@ test("head checker", async (t) => {
   });
 
   await t.test("accepts a self-referential canonical", async () => {
-    const { findings } = await check(SOUND_HEAD);
+    /* Served, not set: on about:blank the href cannot be resolved at all,
+       so this passed for as long as it existed without measuring anything. */
+    const { findings } = await check(SOUND_HEAD, { serve: "/" });
 
     assert.strictEqual(matching(findings, /canonical/).length, 0);
+  });
+
+  await t.test("accepts a canonical that only spells this page differently", async () => {
+    /* Found on takeshisakuma.github.io: read at "/", canonical "/index.html".
+       The same document on every static host, and choosing one spelling is
+       what the tag is for - but it was reported as the page disowning
+       itself, which is the most serious thing this checker says about a
+       canonical. */
+    const cases = [
+      ["/index.html", "a directory index"],
+      ["/index.htm", "the other index extension"],
+      ["/index.php", "an index served by php"],
+      [".", "the directory itself"],
+    ];
+
+    for (const [href, what] of cases) {
+      const { findings } = await check(
+        `<title>t</title><link rel="canonical" href="${href}">`,
+        { serve: "/" }
+      );
+
+      assert.strictEqual(
+        matching(findings, /canonical points at another/).length,
+        0,
+        `${what} is not another page`
+      );
+    }
+  });
+
+  await t.test("still reports a canonical on a genuinely different page", async () => {
+    /* The normalising must not have swallowed the check. */
+    const { findings } = await check(
+      `<title>t</title><link rel="canonical" href="/elsewhere/">`,
+      { serve: "/" }
+    );
+
+    assert.strictEqual(
+      matching(findings, /canonical points at another/).length,
+      1
+    );
   });
 
   await t.test("reports duplicated tags", async () => {

--- a/test/support.js
+++ b/test/support.js
@@ -8,6 +8,7 @@
    in the developer's own Chrome cannot skew a result. */
 
 const fs = require("node:fs");
+const http = require("node:http");
 const path = require("node:path");
 const puppeteer = require("puppeteer");
 
@@ -71,16 +72,51 @@ function installI18n(table) {
 }
 
 /**
+ * Serve one document from a throwaway port.
+ *
+ * setContent leaves the page at about:blank, where a relative URL cannot be
+ * resolved at all - new URL("/x", "about:blank") throws, because about: is
+ * not hierarchical. Anything that reads location or resolves an href is
+ * therefore untestable that way, and worse, passes: a check that quietly
+ * measures nothing looks exactly like a check that found nothing wrong.
+ * That is how the self-referential canonical test came to assert nothing
+ * for as long as it existed.
+ *
+ * @param {string} body
+ * @returns {Promise<import("node:http").Server>}
+ */
+function serveOnce(body) {
+  return new Promise((resolve) => {
+    const server = http.createServer((request, response) => {
+      response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      response.end(body);
+    });
+
+    server.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+/**
  * Open a page with the stylesheet and the named checkers already injected,
  * hand it to the caller, and close the browser afterwards.
  *
+ * Pass `serve` - a path such as "/" - to load the document over http from a
+ * local port instead of setting it directly, which is what anything reading
+ * location or resolving a relative URL needs.
+ *
  * @template T
- * @param {{ html: string, checkers?: (keyof typeof SCRIPTS)[], width?: number, height?: number, hasTouch?: boolean }} options
+ * @param {{ html: string, checkers?: (keyof typeof SCRIPTS)[], width?: number, height?: number, hasTouch?: boolean, serve?: string }} options
  * @param {(page: import("puppeteer").Page) => Promise<T>} run
  * @returns {Promise<T>}
  */
-async function withPage({ html, checkers = [], width, height, hasTouch }, run) {
+async function withPage(
+  { html, checkers = [], width, height, hasTouch, serve },
+  run
+) {
   const browser = await puppeteer.launch({ channel: "chrome" });
+
+  /** @type {import("node:http").Server | null} */
+  let server = null;
 
   try {
     const page = await browser.newPage();
@@ -89,9 +125,19 @@ async function withPage({ html, checkers = [], width, height, hasTouch }, run) {
       await page.setViewport({ width, height, hasTouch: Boolean(hasTouch) });
     }
 
-    await page.setContent(
-      `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>${html}</body></html>`
-    );
+    const document = `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>${html}</body></html>`;
+
+    if (serve) {
+      server = await serveOnce(document);
+
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+
+      await page.goto(`http://127.0.0.1:${port}${serve}`);
+    } else {
+      await page.setContent(document);
+    }
+
     await page.addStyleTag({ content: css });
     await page.evaluate(installI18n, messages);
 
@@ -104,6 +150,7 @@ async function withPage({ html, checkers = [], width, height, hasTouch }, run) {
     return await run(page);
   } finally {
     await browser.close();
+    server?.close();
   }
 }
 


### PR DESCRIPTION
Reported from real use: `https://takeshisakuma.github.io/` said

> canonical points at another page, so this one asks not to be treated as the original: https://takeshisakuma.github.io/index.html

`/` and `/index.html` are the same document on every static host, and choosing one spelling over the other is what the tag is for. The comparison was two strings.

## Fix

The finding is the most serious thing this checker says about a canonical — that the page disowns itself — so it has to mean a different **page**, not a different **spelling** of this one. Directory indexes (`index.html`, `.htm`, `.php`) and a trailing slash are normalised away before comparing.

A different host or scheme is still reported. Also ordinary canonicalisation, but worth a person's glance in a way that `index.html` is not, and the finding is a note rather than an alert.

## The older problem this uncovered

Fixing it needed an environment where a relative URL resolves, and there wasn't one.

`setContent` leaves the page at `about:blank`. `new URL("/x", "about:blank")` **throws** — `about:` is not hierarchical — so `resolve()` returned null, no finding was ever made, and:

```js
await t.test("accepts a self-referential canonical", async () => {
  const { findings } = await check(SOUND_HEAD);
  assert.strictEqual(matching(findings, /canonical/).length, 0);
});
```

passed by measuring nothing, for as long as it existed. That is the failure mode worth naming: **a check that quietly measures nothing looks exactly like a check that found nothing wrong.**

`withPage` now takes `serve`, which loads the document over http from a throwaway port. The canonical tests use it, including the one above — which now actually asserts something.

## Testing

`npm test` — 110 pass, 0 fail.

Verified the fix is load bearing: restoring the string comparison fails the new case with

```
AssertionError: a directory index is not another page
```

Version stays at 0.8.0 (in review). This ships with 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)