### PR TITLE
Stop a canonical that drops tracking parameters reading as another page

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -192,12 +192,26 @@ an HTML document a type selector matches every namespace, so the `<title>`
 elements inside inline SVG — the accessible names of the icons — were
 counted as document titles. Fixed by scoping to `head > title`.
 
-Worth noting how it was found, because it argues for this whole section.
-The check is a one-line `querySelectorAll` that reads correctly, has a test
-behind it, and was wrong on the first real site it met. Nothing short of
-running it on a page somebody actually built would have surfaced it. The
-same is true of the questions above, which is why they are still open
-rather than guessed at.
+Also 2026-07-20, on `takeshisakuma.github.io` and then on an Amazon ad
+landing URL: the canonical check fired twice on correct pages. First on
+`/index.html` read from `/`, which is one document under two spellings.
+Then on a URL carrying nineteen advertising parameters whose canonical was
+the bare address — which is the most common correct use of the tag there
+is. Both fixed; the second by containment, so a canonical that *drops*
+parameters is canonicalising while one that changes them still reports.
+
+That fix gives up a canonical from `?page=2` to the bare listing, which is
+a real if arguable defect. The trade was deliberate: a finding on every
+ad-tracked URL costs more than a missing one on pagination, because a tool
+that cries wolf on an ad landing page will be ignored on the day it is
+right.
+
+Worth noting how all three were found, because it argues for this whole
+section. Each was a short, readable expression with a test behind it, and
+each was wrong on a real site. Nothing short of running them on pages
+somebody actually built would have surfaced any of it. The same is true of
+the questions above, which is why they are still open rather than guessed
+at.
 
 ### 9. Overlapping alt labels
 

--- a/code/js/headCheck.js
+++ b/code/js/headCheck.js
@@ -85,6 +85,25 @@
    * other is precisely what the tag is for. Reported as a contradiction, it
    * was a false positive on a correctly built site.
    *
+   * Stripping tracking parameters is the same argument again, and the most
+   * common correct use of the tag there is. Arriving at a page from an ad
+   * carries a query string nobody wrote and nobody wants indexed; a
+   * canonical naming the clean address is the page doing its job, not
+   * disowning itself. Reported as a contradiction it fired on Amazon, whose
+   * canonical was the bare URL of the very page being read.
+   *
+   * The query cannot simply be ignored, because it does identify a
+   * different page often enough - ?id=2 is not ?id=1. The rule is
+   * containment: every parameter the canonical names has to be here, with
+   * the same value. A canonical that drops parameters is canonicalising;
+   * one that changes or adds them is pointing somewhere else.
+   *
+   * What this gives up is a canonical from ?page=2 to the bare listing,
+   * which is a real if arguable defect. That is the trade: a finding on
+   * every ad-tracked URL costs more than a missing one on pagination, and
+   * an SEO tool that cries wolf on an ad landing page will be ignored on
+   * the day it is right.
+   *
    * A different host or scheme is still reported. Those are also ordinary
    * canonicalisation, but they are worth a person's glance in a way that a
    * directory index is not, and the finding is a note rather than an alert.
@@ -93,25 +112,36 @@
    * @param {string} b
    */
   const samePage = (a, b) => {
-    /** @param {string} href */
-    const key = (href) => {
-      try {
-        const url = new URL(href);
-        url.hash = "";
-        url.pathname = url.pathname.replace(/\/index\.(html?|php)$/i, "/");
-
-        /* Compared as a key, not rewritten for display, so appending the
-           slash to every path is safe: both sides get it. */
-        if (!url.pathname.endsWith("/")) {
-          url.pathname += "/";
-        }
-        return url.href;
-      } catch (error) {
-        return href;
-      }
+    /** @param {URL} url */
+    const path = (url) => {
+      const withoutIndex = url.pathname.replace(/\/index\.(html?|php)$/i, "/");
+      return withoutIndex.endsWith("/") ? withoutIndex : `${withoutIndex}/`;
     };
 
-    return key(a) === key(b);
+    /** @type {URL} */
+    let target;
+    /** @type {URL} */
+    let here;
+
+    try {
+      target = new URL(a);
+      here = new URL(b);
+    } catch (error) {
+      return a === b;
+    }
+
+    /* origin covers scheme, host and port together. */
+    if (target.origin !== here.origin || path(target) !== path(here)) {
+      return false;
+    }
+
+    for (const [name, value] of target.searchParams) {
+      if (here.searchParams.get(name) !== value) {
+        return false;
+      }
+    }
+
+    return true;
   };
 
   /** @param {string | null} value */

--- a/test/head.test.js
+++ b/test/head.test.js
@@ -181,6 +181,37 @@ test("head checker", async (t) => {
     }
   });
 
+  await t.test("accepts a canonical that drops tracking parameters", async () => {
+    /* Found on an Amazon ad landing URL: nineteen advertising parameters in
+       the address, canonical set to the bare page. Naming the clean address
+       is the most common correct use of the tag there is, and it was being
+       reported as the page disowning itself. */
+    const { findings } = await check(
+      `<title>t</title><link rel="canonical" href="/">`,
+      { serve: "/?tag=hydraamazonav-22&ref=pd_sl_7ibq2d37on_e&hvadid=675114138690" }
+    );
+
+    assert.strictEqual(
+      matching(findings, /canonical points at another/).length,
+      0,
+      "dropping an ad's parameters is canonicalising, not disowning"
+    );
+  });
+
+  await t.test("still reports a canonical that changes a parameter", async () => {
+    /* The query cannot simply be ignored: ?id=2 is not ?id=1. The rule is
+       containment, and a changed value is not contained. */
+    const { findings } = await check(
+      `<title>t</title><link rel="canonical" href="/?id=2">`,
+      { serve: "/?id=1" }
+    );
+
+    assert.strictEqual(
+      matching(findings, /canonical points at another/).length,
+      1
+    );
+  });
+
   await t.test("still reports a canonical on a genuinely different page", async () => {
     /* The normalising must not have swallowed the check. */
     const { findings } = await check(


### PR DESCRIPTION
Reported from real use. An Amazon ad landing URL carries nineteen advertising parameters —

```
https://www.amazon.co.jp/?&tag=hydraamazonav-22&ref=pd_sl_7ibq2d37on_e
  &adgrpid=…&hvadid=675114138690&hvtargid=…&hydadcr=27922_14701883&…
```

— and sets its canonical to `https://www.amazon.co.jp/`, the bare address of the very page being read. Krafty called that *"the page declares itself not the original"*.

## Why it is wrong

Naming the clean address is **the most common correct use of the tag there is**. Arriving from an ad carries a query string nobody wrote and nobody wants indexed; stripping it is the page doing its job.

Same argument as the `index.html` fix earlier today, one layer further in.

## The rule

The query cannot simply be ignored — it does identify a different page often enough, and `?id=2` is not `?id=1`.

**Containment.** Every parameter the canonical names has to be present here with the same value:

| current | canonical | verdict |
|---|---|---|
| `/?tag=x&ref=y` | `/` | same page — canonical drops parameters |
| `/?id=1` | `/?id=2` | **reported** — value changed |
| `/` | `/?utm_source=x` | **reported** — canonical adds a parameter |
| `/a/` | `/b/` | **reported** — different path |

Host and scheme are compared as before, through `origin`.

## What this gives up, deliberately

A canonical from `?page=2` to the bare listing, which is a real if arguable defect.

The trade: **a finding on every ad-tracked URL costs more than a missing one on pagination**, because a tool that cries wolf on an ad landing page will be ignored on the day it is right.

## Testing

`npm test` — 120 pass, 0 fail. Two new tests, one either side of the line.

Verified the fix is load bearing: comparing the query strings whole fails the first with

```
AssertionError: dropping an ad's parameters is canonicalising, not disowning
```

## Roadmap

Recorded under item 8, which now has **three findings from real use in one day** — the SVG `<title>` count, `/index.html`, and this. Each was a short readable expression with a test behind it, and each was wrong on a real site. That is the argument for the "waiting on real use" section existing.

Version stays at **0.8.0** (in review). This ships with 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
