### PR TITLE
Stop calling an array of og:image a duplicated tag

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -206,7 +206,17 @@ ad-tracked URL costs more than a missing one on pagination, because a tool
 that cries wolf on an ad landing page will be ignored on the day it is
 right.
 
-Worth noting how all three were found, because it argues for this whole
+And on `github.com`, which ships three `og:image` tags, each followed by its
+own `og:image:type`, `:width` and `:height`. Reported as a duplicated tag.
+Open Graph documents a property repeating exactly like that, and `og:image`
+is the one everybody uses that way, so this was a defect finding on a page
+following the specification. Dropped from the duplicate check — `og:title`
+stays, because nothing treats that as an array. The count moved to the
+reference row instead, which now reads "(1 of 3)": only the first is
+previewed, and a reader looking at one picture should know there were
+others.
+
+Worth noting how all four were found, because it argues for this whole
 section. Each was a short, readable expression with a test behind it, and
 each was wrong on a real site. Nothing short of running them on pages
 somebody actually built would have surfaced any of it. The same is true of

--- a/code/_locales/en/messages.json
+++ b/code/_locales/en/messages.json
@@ -417,6 +417,16 @@
       }
     }
   },
+  "headOneOfSeveral": {
+    "message": "(1 of $count$)",
+    "description": "Open Graph lets og:image repeat. Only the first is previewed, so the row says how many there were.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
+  },
   "valueNotSet": {
     "message": "(not set)",
     "description": "Shown when a metadata tag is absent."

--- a/code/_locales/ja/messages.json
+++ b/code/_locales/ja/messages.json
@@ -417,6 +417,16 @@
       }
     }
   },
+  "headOneOfSeveral": {
+    "message": "($count$ 件中の1件目)",
+    "description": "Open Graph lets og:image repeat. Only the first is previewed, so the row says how many there were.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
+  },
   "valueNotSet": {
     "message": "(未設定)",
     "description": "Shown when a metadata tag is absent."

--- a/code/js/headCheck.js
+++ b/code/js/headCheck.js
@@ -247,7 +247,17 @@
   reportDuplicates('meta[name="description" i]', "description");
   reportDuplicates('link[rel~="canonical" i]', "canonical");
   reportDuplicates('meta[property="og:title" i]', "og:title");
-  reportDuplicates('meta[property="og:image" i]', "og:image");
+
+  /* og:image is deliberately absent from that list. Open Graph allows a
+     property to be an array, and og:image is the one everybody uses that
+     way: several images, each followed by its own og:image:type, :width and
+     :height, for the platform to choose from. github.com ships three, which
+     this reported as a duplicated tag - a defect finding on a page doing
+     something the specification documents.
+
+     The count is not thrown away, only moved. The reference row below says
+     which of how many it is showing, because a reader looking at one
+     picture should know there were others. */
 
   /* --- what only a person can decide --- */
 
@@ -391,7 +401,15 @@
     { label: "og:title", value: ogTitle, count: true },
     { label: "og:type", value: metaByProperty("og:type") },
     { label: "og:url", value: metaByProperty("og:url"), url: true },
-    { label: "og:image", value: ogImage, image: "ogp", url: true },
+    {
+      label: "og:image",
+      value: ogImage,
+      image: "ogp",
+      url: true,
+      /* Open Graph lets this be an array, and only the first is previewed.
+         Saying so beats letting a reader think one is all there is. */
+      of: document.querySelectorAll('meta[property="og:image" i]').length,
+    },
     { label: "og:description", value: ogDescription, count: true },
     { label: "og:site_name", value: metaByProperty("og:site_name") },
     { label: "og:locale", value: metaByProperty("og:locale") },
@@ -415,7 +433,7 @@
 
   const referenceSection = section("headSectionReference");
 
-  for (const { label, value, count, image, url } of rows) {
+  for (const { label, value, count, image, url, of } of rows) {
     const row = document.createElement("div");
     row.className = "kraftyRow";
 
@@ -442,6 +460,15 @@
         String(length(value)),
       ]);
       head.appendChild(characters);
+    }
+
+    /* A property the specification lets repeat, where only the first is
+       shown. Not a finding - the row simply says which of how many. */
+    if (of && of > 1) {
+      const which = document.createElement("span");
+      which.className = "kraftyRowCount";
+      which.textContent = kraftyMessage("headOneOfSeveral", [String(of)]);
+      head.appendChild(which);
     }
 
     const line = document.createElement("div");

--- a/test/head.test.js
+++ b/test/head.test.js
@@ -284,6 +284,77 @@ test("head checker", async (t) => {
     assert.strictEqual(matching(findings, /title appears 2 times/).length, 1);
   });
 
+  await t.test("does not call several og:image a duplicated tag", async () => {
+    /* Found on github.com, which ships three of them with their own
+       og:image:type, :width and :height. Open Graph documents a property
+       repeating like this, so reporting it was a defect finding on a page
+       following the specification. */
+    const result = await withPage(
+      { html: "<p>page</p>", checkers: [] },
+      async (page) => {
+        await page.evaluate(() => {
+          document.head.insertAdjacentHTML(
+            "beforeend",
+            `<title>t</title>
+             <meta property="og:image" content="https://example.com/a.png">
+             <meta property="og:image:width" content="1200">
+             <meta property="og:image" content="https://example.com/b.png">
+             <meta property="og:image:width" content="1200">
+             <meta property="og:image" content="https://example.com/c.png">`
+          );
+        });
+
+        const { SCRIPTS } = require("./support.js");
+        await page.evaluate(SCRIPTS.headCheck);
+
+        return page.evaluate(() => {
+          const panel = document.getElementById("js-kraftyHeadInformation");
+
+          const row = [...(panel?.querySelectorAll(".kraftyRow") ?? [])].find(
+            (candidate) =>
+              candidate.querySelector("strong")?.textContent === "og:image"
+          );
+
+          return {
+            /* Same shape check() returns, so matching() works on it. */
+            findings: [...(panel?.querySelectorAll(".kraftyCheck") ?? [])].map(
+              (item) => ({
+                level: item.classList.contains("kraftyCheck-alert")
+                  ? "alert"
+                  : "note",
+                text: item.textContent ?? "",
+              })
+            ),
+            rowText: row?.textContent ?? "",
+          };
+        });
+      }
+    );
+
+    assert.strictEqual(
+      matching(result.findings, /og:image appears/).length,
+      0,
+      "an array of og:image is what the specification describes"
+    );
+
+    /* The count is not thrown away, only moved: a reader looking at one
+       preview should know there were three. */
+    assert.match(result.rowText, /3/);
+    assert.match(result.rowText, /a\.png/);
+  });
+
+  await t.test("still reports a duplicated og:title", async () => {
+    /* Only og:image is an array in practice. Removing it from the duplicate
+       check must not have removed the check. */
+    const { findings } = await check(
+      `<title>t</title>
+       <meta property="og:title" content="one">
+       <meta property="og:title" content="two">`
+    );
+
+    assert.strictEqual(matching(findings, /og:title appears 2 times/).length, 1);
+  });
+
   await t.test("reports a missing lang attribute", async () => {
     const { findings } = await check(SOUND_HEAD);
 


### PR DESCRIPTION
Reported from real use. `github.com` ships three `og:image` tags:

```html
<meta property="og:image" content="…/github-logo-55c5b9a1fe52.png">
<meta property="og:image:type" content="image/png">
<meta property="og:image:width" content="1200">
<meta property="og:image:height" content="1200">
<meta property="og:image" content="…/github-mark-57519b92ca4e.png">
…
```

Krafty reported **"og:image appears 3 times"** — a defect finding on a page following the specification.

## Why it is wrong

Open Graph documents a property repeating exactly like that, and `og:image` is the one everybody uses that way: several images, each followed by its own `og:image:type`, `:width` and `:height`, for the platform to choose between.

It is out of the duplicate check.

## What stays

**`og:title` stays in it.** Nothing treats that as an array, and removing a false positive by removing the check is how a check quietly stops working. There is a test for `og:title` now so that cannot happen unnoticed.

## The count moved rather than vanished

The reference row now reads **`og:image  (1 of 3)`**.

Only the first is previewed, and a reader looking at one picture should know there were others. That is information, not a finding, and it belongs where the values are listed rather than among the things that are wrong.

## Testing

`npm test` — 122 pass, 0 fail. Two new tests: three `og:image` produce no finding but do produce the count in the row, and a duplicated `og:title` is still reported.

`tsc` caught the new test returning bare strings where `matching()` wants `{ level, text }` — the exact drift the cleanup review flagged between the test files. Fixed to the shape the file already uses.

## Roadmap

Fourth false positive from real use today, after the SVG `<title>` count, `/index.html`, and an ad URL's tracking parameters. Recorded under item 8 with the others.

Version stays at **0.8.0** (in review). This ships with 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
