### PR TITLE
Want a table's shape before wanting its headers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -532,6 +532,27 @@ somebody's spacer.
 not need it, so requiring it would have been a finding on the ordinary
 case — the sort of threshold item 8 is on the watch for.
 
+Measured before shipping, which is the lesson of the four false positives
+found the same day. The first version reported twelve tables on
+ja.wikipedia.org and one on amazon.co.jp, and reading them showed the rule
+was wrong rather than the pages: the succession boxes and navigation boxes
+were one row and a handful of cells, and Amazon's was a single empty cell.
+Layout wearing a table's tags.
+
+So the shape has to be a table's before missing headers mean anything: at
+least two rows, since one row cannot have a header row, and at least two
+columns, since one column is a list. Amazon went to zero and Wikipedia to
+seven of thirty-three — the population table and the climate table among
+them, which are real findings.
+
+The rows and cells counted are the table's own. Wikipedia nests tables, and
+a nested one's `th` would otherwise excuse the table around it.
+
+What is left on Wikipedia is genuinely arguable — a positional map of
+neighbouring prefectures reads as a table to a machine and as a diagram to
+a person. Watch it under item 8. If it turns out noisy, the numbers to
+change are the two thresholds in `js/markupCheck.js`.
+
 ### 17. Brightness greyed the panels off the screen — done
 
 Reported 2026-07-20: turning the brightness checker on made some panels

--- a/code/js/markupCheck.js
+++ b/code/js/markupCheck.js
@@ -71,9 +71,30 @@
       .filter(([, count]) => count > 1)
       .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
 
-    /* A table whose cells have no headers to be announced with. Layout
-       tables - the ones with a role saying so - are excluded, because a
-       table used for layout is not claiming to have headers. */
+    /* A table whose cells have no headers to be announced with.
+
+       The shape has to be a table's before the missing headers mean
+       anything, and measuring said so. On ja.wikipedia.org this reported
+       twelve, of which the succession boxes and the navigation boxes - one
+       row, a handful of cells - were layout wearing a table's tags, and on
+       amazon.co.jp the single finding was a one-cell spacer. A table with
+       one row cannot have a header row, and one with a single column is a
+       list. Neither is a data table with something missing.
+
+       Its own rows and cells, not its descendants': Wikipedia nests tables
+       inside tables, and a nested one's `th` would otherwise excuse the
+       table around it. */
+    /**
+     * @param {Element} element
+     * @param {string} child
+     */
+    const own = (element, child) =>
+      [
+        ...element.querySelectorAll(
+          `:scope > ${child}, :scope > thead > ${child}, :scope > tbody > ${child}, :scope > tfoot > ${child}`
+        ),
+      ];
+
     const headerless = [...document.querySelectorAll("table")].filter(
       (table) => {
         if (table.closest(".kraftyPanel")) {
@@ -86,11 +107,22 @@
           return false;
         }
 
-        /* An empty table is somebody's spacer, not a data table missing its
-           headers. */
-        return (
-          table.querySelector("th") === null &&
-          table.querySelector("td") !== null
+        const rows = own(table, "tr");
+
+        if (rows.length < 2) {
+          return false;
+        }
+
+        const widest = Math.max(
+          ...rows.map((row) => row.querySelectorAll(":scope > td").length)
+        );
+
+        if (widest < 2) {
+          return false;
+        }
+
+        return rows.every(
+          (row) => row.querySelectorAll(":scope > th").length === 0
         );
       }
     );

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -136,10 +136,53 @@ test("markup checker", async (t) => {
 
   await t.test("reports a table whose cells have no headers", async () => {
     const result = await check(
-      `<table><tr><td>Tokyo</td><td>3</td></tr></table>`
+      `<table>
+         <tr><td>Tokyo</td><td>3</td></tr>
+         <tr><td>Osaka</td><td>2</td></tr>
+       </table>`
     );
 
     assert.strictEqual(matchingFindings(result, /header cells/).length, 1);
+  });
+
+  await t.test("wants a table's shape before it wants its headers", async () => {
+    /* Measured on ja.wikipedia.org, which reported twelve tables: the
+       succession boxes and navigation boxes - one row, a few cells - were
+       layout wearing a table's tags, and amazon.co.jp's single finding was
+       a one-cell spacer. A table with one row cannot have a header row, and
+       one with a single column is a list. Neither is a data table with
+       something missing. */
+    const oneRow = await check(
+      `<table><tr><td>next</td><td>previous</td><td>index</td></tr></table>`
+    );
+
+    const oneColumn = await check(
+      `<table><tr><td>first</td></tr><tr><td>second</td></tr></table>`
+    );
+
+    const spacer = await check(`<table><tr><td></td></tr></table>`);
+
+    assert.strictEqual(matchingFindings(oneRow, /header cells/).length, 0);
+    assert.strictEqual(matchingFindings(oneColumn, /header cells/).length, 0);
+    assert.strictEqual(matchingFindings(spacer, /header cells/).length, 0);
+  });
+
+  await t.test("does not let a nested table excuse the one around it", async () => {
+    /* Wikipedia nests tables inside tables. Asking the outer one whether a
+       `th` exists anywhere below it would find the inner one's. */
+    const result = await check(
+      `<table>
+         <tr><td>a</td><td><table><tr><th>inner</th><td>x</td></tr>
+                                  <tr><th>also</th><td>y</td></tr></table></td></tr>
+         <tr><td>b</td><td>c</td></tr>
+       </table>`
+    );
+
+    assert.strictEqual(
+      matchingFindings(result, /header cells/).length,
+      1,
+      "the outer table has no headers of its own"
+    );
   });
 
   await t.test("accepts a table that has headers", async () => {


### PR DESCRIPTION
Measured the table check added earlier today against real pages **before** shipping it — the lesson of the four false positives found the same day.

## What the first version reported

| site | tables | flagged |
|---|---|---|
| ja.wikipedia.org (東京都) | 33 | **12** |
| amazon.co.jp | 1 | **1** |

Reading them showed the rule was wrong rather than the pages:

- `1 row, 3 cells` — 「先代東京府・東京市 行政区の変遷」 — a succession box
- `1 row, 4 cells` — 「1896年: アテネ 1900年: パリ …」 — a navigation box
- `1 row, 1 cell, no text` — Amazon's, a spacer

Layout wearing a table's tags.

## The rule now

A table with **one row** cannot have a header row. A table with **one column** is a list. Neither is a data table with something missing, so neither is asked for headers.

| site | tables | flagged before | after |
|---|---|---|---|
| ja.wikipedia.org | 33 | 12 | **7** |
| amazon.co.jp | 1 | 1 | **0** |
| nhk.or.jp/news | 0 | – | 0 |
| brainpad.co.jp | 0 | – | 0 |

The seven on Wikipedia include the population table and the climate table, which are real findings.

Rows and cells counted are the table's **own**, not its descendants'. Wikipedia nests tables, and a nested one's `th` would otherwise excuse the table around it. There is a test for that.

## What is left, honestly

A positional map of neighbouring prefectures reads as a table to a machine and as a diagram to a person. That one is arguable and stays. Recorded under item 8 to watch, with both thresholds named so the next person knows what to change.

`npm test` — 151 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)